### PR TITLE
Avoid storing empty lines in history

### DIFF
--- a/lib/input.js
+++ b/lib/input.js
@@ -92,7 +92,9 @@ function handle_special_keys(ch, key){
 }
 
 function return_key(){
-	history.push(command);
+	if(command){
+		history.push(command);	
+	}
 	w(command, 'data/history.txt');
 
 	process.stdout.write('\n');


### PR DESCRIPTION
I sometimes hit return a few times at the terminal to make it clear where a command starts.  This PR means that when someone does this, the behavior matches bash, and the empty command isn't stored in history.
