### PR TITLE
Adding ubuntu support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ $cfsh
 
 Some commands require ssh access to the instances so make sure your ssh key is added to your key ring prior to running Cfsh.
 
+NOTE: For Linux users, install [xdotools](http://manpages.ubuntu.com/manpages/artful/man1/xdotool.1.html) to enjoy all the commands of CFSH on Linux.(Tested on Ubuntu 16.04)
+
 ## Options
 Cfsh uses the same authentication as the [AWS cli tool](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html), so if you can use the AWS cli tool you can use Cfsh. If you use AWS's new standard, the AWS credentials file, you can optionally specify an AWS profile with the -p option. Also, Cfsh defaults to the us-east-1 region but you can specify a AWS region with the -r option.
 ```

--- a/lib/plugins/ec2.js
+++ b/lib/plugins/ec2.js
@@ -5,6 +5,7 @@ var settings = require('../settings');
 var ssh_client = require('node-sshclient');
 var opn = require('opn');
 var fs = require('fs');
+var os = require('os');
 
 var params = { region: settings.region };
 var ec2 = new AWS.EC2(params);
@@ -34,7 +35,7 @@ function EC2(_tree){
 }
 
 EC2.prototype.do_cmd = function(args, opts, callback){
-	
+
 	switch(args[0]){
 		case 'info': info(args, callback); break;
 		case 'cat': cat(args, opts, callback); break;
@@ -354,7 +355,7 @@ function vols(args, callback){
 	var total;
 
 	console.log();
-	
+
 	asg.describeAutoScalingGroups({
 		AutoScalingGroupNames: [tree.current.resource_id]
 	}, function(err, data) {
@@ -639,7 +640,7 @@ function foreach_instances_parallel(asg, func){
 
 function output_ec2_data(i){
 	console.log();
-	
+
 	if(i.ImageId){console.log("ImageId: " + i.ImageId)};
 	if(i.State.Name){console.log("State: " + i.State.Name)};
 	if(i.PrivateDnsName){console.log("Private Dns: " + i.PrivateDnsName)};
@@ -717,8 +718,16 @@ function start_ssh(id, ip, proxy, callback){
 		var command = "echo '" + id + "' && ssh -o StrictHostKeyChecking=no " + settings.ssh_user + "@" + ip;
 	}
 
-	var osa = settings.osa_ssh_command.replace(/{{{command}}}/, command);
-	var ssh = exec(osa, function(){});
+	if(os.platform == 'linux'){
+		var shell_cmd = settings.linux_ssh_command.replace(/{{{command}}}/, command);
+	}else{
+		var shell_cmd = settings.osa_ssh_command.replace(/{{{command}}}/, command);
+	}
+
+	var ssh = exec(shell_cmd, function(error, out, err){
+		if(error!==null) console.log(error);
+	});
+
 	setTimeout(callback, 750);
 }
 
@@ -735,9 +744,18 @@ function ssh_forward(id, ip, forward_port, dest_port, proxy, callback){
 			command = "echo '" + id + "' && ssh -o StrictHostKeyChecking=no -L " + forward_port + ":localhost:" + dest_port + " " + settings.ssh_user + "@" + ip;
 		}
 
-		var osa = settings.osa_ssh_command.replace(/{{{command}}}/, command);
-		var ssh = exec(osa, function(){
-			opn('http://localhost:' + forward_port);
+		if(os.platform == 'linux'){
+			var shell_cmd = settings.linux_ssh_command.replace(/{{{command}}}/, command);
+		}else{
+			var shell_cmd = settings.osa_ssh_command.replace(/{{{command}}}/, command);
+		}
+
+		var ssh = exec(shell_cmd, function(error, out, err){
+			if(error!==null){
+				console.log(error);
+			}else{
+				opn('http://localhost:' + forward_port);
+			}
 		});
 	}else{
 		return;

--- a/lib/settings.js.dist
+++ b/lib/settings.js.dist
@@ -76,6 +76,8 @@ module.exports = {
 
 	osa_ssh_command: 'osascript -e \'tell application "Terminal" to activate\' -e \'tell application "System Events" to tell process "Terminal" to keystroke "t" using command down\' -e \'tell application "Terminal" to do script "{{{command}}}" in selected tab of the front window\'',
 
+	linux_ssh_command: 'xdotool key ctrl+shift+t sleep 2 type \'{{{command}}}\n\'',
+
 	proxy_alias: 'bastion'
 
 }


### PR DESCRIPTION
This adds support for Ubuntu machines as well as preciously `ssh` was not working for them.
It uses `xdotool` to open a new terminal and fire up the ssh command in there(visible to user).
Also, it throws an error if occurs.